### PR TITLE
set Client audio sampleRate during initialization

### DIFF
--- a/rtspserver/src/main/java/com/pedro/rtspserver/RtspServer.kt
+++ b/rtspserver/src/main/java/com/pedro/rtspserver/RtspServer.kt
@@ -122,6 +122,7 @@ class RtspServer(context: Context, private val connectCheckerRtsp: ConnectChecke
 
     init {
       commandsManager.setIsStereo(isStereo)
+      commandsManager.sampleRate = sampleRate
       commandsManager.setVideoInfo(sps, pps, vps)
     }
 


### PR DESCRIPTION
set Client audio sampleRate during initialization otherwise it reports default 32000 to client which produces distorted audio playing in client for any other sample rate