### PR TITLE
fix: add rtsp:// url prefix to content-base of the SDP

### DIFF
--- a/rtspserver/src/main/java/com/pedro/rtspserver/RtspServer.kt
+++ b/rtspserver/src/main/java/com/pedro/rtspserver/RtspServer.kt
@@ -32,6 +32,7 @@ open class RtspServer(
   private val clients = mutableListOf<ServerClient>()
   private var thread: Thread? = null
   private var running = false
+  private var isEnableLogs = true
   private val semaphore = Semaphore(0)
   private val serverCommandManager = ServerCommandManager()
   private var clientListener: ClientListener? = null
@@ -110,6 +111,7 @@ open class RtspServer(
           }
           val client = ServerClient(clientSocket, serverIp, port, connectChecker, clientAddress,
             serverCommandManager, this)
+          client.setLogs(isEnableLogs)
           client.start()
           synchronized(clients) {
             clients.add(client)
@@ -170,6 +172,7 @@ open class RtspServer(
   }
 
   fun setLogs(enable: Boolean) {
+    isEnableLogs = enable;
     synchronized(clients) {
       clients.forEach { it.setLogs(enable) }
     }

--- a/rtspserver/src/main/java/com/pedro/rtspserver/ServerCommandManager.kt
+++ b/rtspserver/src/main/java/com/pedro/rtspserver/ServerCommandManager.kt
@@ -167,7 +167,7 @@ open class ServerCommandManager: CommandsManager() {
 
   private fun createDescribe(cSeq: Int, clientIp: String): String {
     val body = createBody(clientIp)
-    return "${createHeader(cSeq)}Content-Length: ${body.length}\r\nContent-Base: $serverIp:$serverPort/\r\nContent-Type: application/sdp\r\n\r\n$body"
+    return "${createHeader(cSeq)}Content-Length: ${body.length}\r\nContent-Base: rtsp://$serverIp:$serverPort/\r\nContent-Type: application/sdp\r\n\r\n$body"
   }
 
   private fun createBody(clientIp: String): String {


### PR DESCRIPTION
## Details
The `Content-Base` attribute of the SDP is missing the `rtsp://` prefix.  This is preventing the MediaMtx service from connecting to the RTSP-Server.  See #108.

## Fix
The `rtsp:// `prefix is added to the `Content-Base` attribute of the SDP.

## Logging
While making this change, the ServerClient logs were disabled via the StreamClient at startup. However, because the state of the logs is not maintained, new ServerClient instances were not picking up the state of the logs.  This state is now added to the RtspServer and applied to all new instances of the ServerClient.